### PR TITLE
Improvements to surfaces, time travel code, and an attempt to fix YYC.

### DIFF
--- a/SonicTimeTwisted.gmx/extensions/SttAndroidGamepad.extension.gmx
+++ b/SonicTimeTwisted.gmx/extensions/SttAndroidGamepad.extension.gmx
@@ -28,7 +28,7 @@
       <CopyToMask>2097160</CopyToMask>
     </Config>
     <Config name="Windows">
-      <CopyToMask>9223372036854775807</CopyToMask>
+      <CopyToMask>8</CopyToMask>
     </Config>
     <Config name="AndroidSmartphone">
       <CopyToMask>105553895358702</CopyToMask>
@@ -66,7 +66,7 @@
           <CopyToMask>9223372036854775807</CopyToMask>
         </Config>
         <Config name="Windows">
-          <CopyToMask>9223372036854775807</CopyToMask>
+          <CopyToMask>8</CopyToMask>
         </Config>
         <Config name="AndroidSmartphone">
           <CopyToMask>9223372036854775807</CopyToMask>

--- a/SonicTimeTwisted.gmx/objects/objFinalBossBackground.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objFinalBossBackground.object.gmx
@@ -44,10 +44,8 @@ angle_change = 2;
 angle_warp = -15;
 scale = 1.1;
 sampler_index_warp = shader_get_sampler_index(NebulaShader, "warp");
-surface_warp = surface_create(256, 256);
-draw_clear_alpha(0, 0);
-surface_reset_target();
-texture_warp = surface_get_texture(surface_warp);
+surface_warp = -1;
+texture_warp = pointer_null;
 whirl_angle = 0;
 //var relative_y;
 // defaults

--- a/SonicTimeTwisted.gmx/objects/objPPBackground.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objPPBackground.object.gmx
@@ -86,11 +86,8 @@ angle_change = 2;
 angle_warp = -15;
 scale = 1.1;
 sampler_index_warp = shader_get_sampler_index(NebulaShader, "warp");
-surface_warp = surface_create(256, 256);
-//surface_set_target(surface_warp);
-draw_clear_alpha(0, 0);
-surface_reset_target();
-texture_warp = surface_get_texture(surface_warp);
+surface_warp = -1;
+texture_warp = pointer_null;
 whirl_angle = 0;
 </string>
           </argument>

--- a/SonicTimeTwisted.gmx/objects/objProgram.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objProgram.object.gmx
@@ -26,6 +26,14 @@
           <argument>
             <kind>1</kind>
             <string>/// Initialize
+
+// restore VM math precision as early as possible, if it's YYC.
+if (code_is_compiled())
+{
+    show_debug_message("YYC is enabled, expect weird behaviour.");
+    math_set_epsilon(0.00001);
+}
+
 image_speed = 0;
 level = "";
 /* AUTHOR NOTE: This object controls all global game operations, such as the

--- a/SonicTimeTwisted.gmx/objects/objProgram.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objProgram.object.gmx
@@ -71,8 +71,6 @@ stop_sound = true;
 ss_perfect_bonus = 0;
 ss_rings_bonus = 0;
 ss_time_bonus = 0;
-//game_directory="%localappdata%\Sonic_Time_Twisted\"
-game_directory="\Sonic_Time_Twisted\";
 // music
 jingle = -1;
 music = -1;

--- a/SonicTimeTwisted.gmx/objects/objSSScoreBackground.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objSSScoreBackground.object.gmx
@@ -139,7 +139,7 @@ else
     menu.state = menuStatus;
     with(menu)
     {
-        delay_timer = delay_timer_default;
+        delay_timer = 0;
         event_user(1);
     }
 }

--- a/SonicTimeTwisted.gmx/objects/objSaveControl.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objSaveControl.object.gmx
@@ -98,7 +98,7 @@ if(is_touchscreen)
     // hints update
     event_user(3);
 }
-hint_surface = surface_create(512, 512);
+hint_surface = -1;
 hint_up_to_date = false;
 </string>
           </argument>

--- a/SonicTimeTwisted.gmx/objects/objScreen.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objScreen.object.gmx
@@ -28,6 +28,7 @@
             <string>/// Screen settings
 width = 426;
 height = 240;
+vsync = true; // enabled by default.
 window_mode = 1;
 window_scale = 2;
 window_state = 2;
@@ -109,6 +110,31 @@ window_center();
             <kind>1</kind>
             <string>/// Unpause
 if not paused and screenshot &gt; -1 { background_delete(screenshot); screenshot = -1; }
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
+    <event eventtype="7" enumb="12">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>///toggle vertical sync.
+vsync = !vsync;
+apply_video_settings();
 </string>
           </argument>
         </arguments>

--- a/SonicTimeTwisted.gmx/objects/objTimeTravelVortex.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objTimeTravelVortex.object.gmx
@@ -133,7 +133,7 @@ x=truex;
 
 // draw the surface again below, without the shader
 // so you can see the untextured animation
-draw_surface(tt_surface, 0,512);
+if (surface_exists(tt_surface)) draw_surface(tt_surface, 0,512);
 
 
 

--- a/SonicTimeTwisted.gmx/objects/objTitleLighting.object.gmx
+++ b/SonicTimeTwisted.gmx/objects/objTitleLighting.object.gmx
@@ -54,6 +54,36 @@ spr=sprite_index;
         <arguments>
           <argument>
             <kind>1</kind>
+            <string>/// Check Surface Exists
+if (!surface_exists(tt_surface) &amp;&amp; view_yview &lt; room_height - view_hview - 64)
+{
+    tt_surface = surface_create(426, 240);
+}
+if (view_yview &gt;= room_height - view_hview - 64)
+{
+    if (surface_exists(tt_surface)) surface_free(tt_surface);
+    exit;
+}
+</string>
+          </argument>
+        </arguments>
+      </action>
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
             <string>// set the drawing target to the surface
 var temp_Detail = 30;
 var temp_Centre = 213;
@@ -125,35 +155,6 @@ surface_reset_target();
 // increase the shift amount; this will cycle the colours
 shift += 0.01;
 time++;
-</string>
-          </argument>
-        </arguments>
-      </action>
-      <action>
-        <libid>1</libid>
-        <id>603</id>
-        <kind>7</kind>
-        <userelative>0</userelative>
-        <isquestion>0</isquestion>
-        <useapplyto>-1</useapplyto>
-        <exetype>2</exetype>
-        <functionname></functionname>
-        <codestring></codestring>
-        <whoName>self</whoName>
-        <relative>0</relative>
-        <isnot>0</isnot>
-        <arguments>
-          <argument>
-            <kind>1</kind>
-            <string>/// Check Surface Exists
-if (!surface_exists(tt_surface) &amp;&amp; view_yview &lt; room_height - view_hview - 64)
-{
-    tt_surface = surface_create(426, 240);
-}
-if (view_yview &gt;= room_height - view_hview - 64)
-{
-    surface_free(tt_surface);
-}
 </string>
           </argument>
         </arguments>

--- a/SonicTimeTwisted.gmx/scripts/apply_video_settings.gml
+++ b/SonicTimeTwisted.gmx/scripts/apply_video_settings.gml
@@ -9,6 +9,8 @@ Video modes:
 if(DEVICE_INFO & DEVICE_TYPE_COMPUTER)
 {
     with objScreen {        
+        display_set_windows_alternate_sync(vsync);
+        display_reset(0, vsync);
         if(video_mode >= 0 && video_mode < 3)
         {
             window_state = video_mode + 1;

--- a/SonicTimeTwisted.gmx/scripts/delete_settings.gml
+++ b/SonicTimeTwisted.gmx/scripts/delete_settings.gml
@@ -1,10 +1,6 @@
 //delete_settings
-if file_exists(working_directory+"\settings.ini") {
-    file_delete(working_directory+"\settings.ini");
-}
-/*
 if file_exists("settings.ini") {
     file_delete("settings.ini");
 }
-*/
+
 with objProgram.inputManager input_load();

--- a/SonicTimeTwisted.gmx/scripts/load_options.gml
+++ b/SonicTimeTwisted.gmx/scripts/load_options.gml
@@ -1,4 +1,4 @@
-var file = working_directory+"\settings.ini";
+var file = "settings.ini";
 if (file_exists(file)) {
     ini_open(file);
     

--- a/SonicTimeTwisted.gmx/scripts/load_options.gml
+++ b/SonicTimeTwisted.gmx/scripts/load_options.gml
@@ -7,6 +7,7 @@ if (file_exists(file)) {
         video_mode = ini_read_real('video_options', "mode", 0);
         flashing_reduced = ini_read_real('video_options', "flashing_reduced", 1);
         score_tally_mode = ini_read_real('video_options', "score_tally_mode", 0);
+        vsync = ini_read_real('video_options', "vsync", true);
         
         // apply settings
         apply_video_settings();

--- a/SonicTimeTwisted.gmx/scripts/menu_fn_init.gml
+++ b/SonicTimeTwisted.gmx/scripts/menu_fn_init.gml
@@ -76,8 +76,8 @@ scroll_max = 0;
 scroll_target = 0;
 scrollable = false;
 
-s = surface_create(512, 256);
-scrollable_s = surface_create(512, 256);
+s = -1;
+scrollable_s = -1;
 
 // these variables are calculated in item scripts for default displays and shouldn't be directly used in action scripts
 internal__draw_menu_rect_x1 = 0;

--- a/SonicTimeTwisted.gmx/scripts/menu_part_videooptions_actions.gml
+++ b/SonicTimeTwisted.gmx/scripts/menu_part_videooptions_actions.gml
@@ -13,6 +13,9 @@ switch(argument0)
         objScreen.flashing_reduced = !objScreen.flashing_reduced;
         break;
     case 3:
+        with (objScreen) event_user(2);
+        break;
+    case 4:
     case -1:
         menu_fn_exit_submenu(menu_part_options_items, 0);
         break;
@@ -30,11 +33,14 @@ switch(argument0)
                 objScreen.score_tally_mode--;
                 if(objScreen.score_tally_mode < 0)
                 {
-                    objScreen.score_tally_mode = 2
+                    objScreen.score_tally_mode = 2;
                 }
                 break;
             case 2:
                 objScreen.flashing_reduced = !objScreen.flashing_reduced;
+                break;
+            case 3:
+                with (objScreen) event_user(2);
                 break;
         }
         break;
@@ -53,6 +59,9 @@ switch(argument0)
                 break;
             case 2:
                 objScreen.flashing_reduced = !objScreen.flashing_reduced;
+                break;
+            case 3:
+                with (objScreen) event_user(2);
                 break;
         }
         break;
@@ -96,6 +105,15 @@ if(objScreen.flashing_reduced)
 else
 {
     menu_fn_refresh_displayed_value(2, "< "+tr("Off")+ " >");
+}
+
+if(objScreen.vsync)
+{
+    menu_fn_refresh_displayed_value(3, "< "+tr("On")+ " >");
+}
+else
+{
+    menu_fn_refresh_displayed_value(3, "< "+tr("Off")+ " >");
 }
 
 // preserve the cursor value - usually false for the sake of touchscreen controls

--- a/SonicTimeTwisted.gmx/scripts/menu_part_videooptions_items.gml
+++ b/SonicTimeTwisted.gmx/scripts/menu_part_videooptions_items.gml
@@ -7,7 +7,11 @@ if(DEVICE_INFO & DEVICE_TYPE_COMPUTER)
 }
 menu_fn_add_option(tr("Score tally mode"), 1, 1, "");
 menu_fn_add_option(tr("Flashing reduction"), 2, 1, "");
-menu_fn_add_option(tr("< Back"), 3);
+if (DEVICE_INFO & DEVICE_TYPE_COMPUTER)
+{
+    menu_fn_add_option(tr("VSync"), 3, 1, "");
+}
+menu_fn_add_option(tr("< Back"), 4);
 
 button_width = 350;
 

--- a/SonicTimeTwisted.gmx/scripts/save_control_map_android_device.gml
+++ b/SonicTimeTwisted.gmx/scripts/save_control_map_android_device.gml
@@ -1,6 +1,6 @@
 // argument0 - button code
 // argument1 - value
-ini_open(working_directory+"\settings.ini");
+ini_open("settings.ini");
 ini_write_real('android_input_controls', "mode", round(android_get_input_mode()));
 ini_write_string('android_input_controls', menu_fn_get_keymap_getkey(argument0), string(argument1));
 ini_close();

--- a/SonicTimeTwisted.gmx/scripts/save_control_map_gamepad.gml
+++ b/SonicTimeTwisted.gmx/scripts/save_control_map_gamepad.gml
@@ -1,4 +1,4 @@
 //save_control_map(control,inputButton)
-ini_open(working_directory+"\settings.ini");
+ini_open("settings.ini");
 ini_write_string('gamepad_controls', string(argument0), string(argument1));
 ini_close();

--- a/SonicTimeTwisted.gmx/scripts/save_control_map_keyboard.gml
+++ b/SonicTimeTwisted.gmx/scripts/save_control_map_keyboard.gml
@@ -1,4 +1,4 @@
 //save_control_map(control,inputButton)
-ini_open(working_directory+"\settings.ini");
+ini_open("settings.ini");
 ini_write_real('keyboard_controls', argument0, round(argument1));
 ini_close();

--- a/SonicTimeTwisted.gmx/scripts/save_options.gml
+++ b/SonicTimeTwisted.gmx/scripts/save_options.gml
@@ -1,4 +1,4 @@
-ini_open(working_directory+"\settings.ini");
+ini_open("settings.ini");
 if(instance_exists(objScreen))
 {
     ini_write_real('video_options', "mode", objScreen.video_mode);

--- a/SonicTimeTwisted.gmx/scripts/save_options.gml
+++ b/SonicTimeTwisted.gmx/scripts/save_options.gml
@@ -4,6 +4,7 @@ if(instance_exists(objScreen))
     ini_write_real('video_options', "mode", objScreen.video_mode);
     ini_write_real('video_options', "flashing_reduced", objScreen.flashing_reduced);
     ini_write_real('video_options', 'score_tally_mode', objScreen.score_tally_mode);
+    ini_write_real('video_options', "vsync", objScreen.vsync);
 }
 if(instance_exists(objProgram.inputManager))
 {

--- a/SonicTimeTwisted.gmx/scripts/timetravel_shader_draw.gml
+++ b/SonicTimeTwisted.gmx/scripts/timetravel_shader_draw.gml
@@ -3,15 +3,18 @@
 // argument2 - surface draw x
 // argument3 - surface draw y
 
-shader_set(TimeTravelShader);
-
-    // send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
-    shader_set_uniform_f(param_scl, argument0 / tt_width, argument1 / tt_height);
-    // send: the texture index of the sparkly SCD texture
-    texture_set_stage(stage_mask, tt_texhandle);
-    // send: the texture index of the the gradient used to cycle the colours
-    texture_set_stage(stage_grad, grad_texhandle);
+if (tts_ok)
+{
+    shader_set(TimeTravelShader);
     
-    shader_set_uniform_f(param_shift, shift); // send the shift amount (for colour cycling) to the shader
-    draw_surface_ext(tt_surface, argument2, argument3, image_xscale, image_yscale, 0, c_white, 1);
-shader_reset();
+        // send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
+        shader_set_uniform_f(param_scl, argument0 / tt_width, argument1 / tt_height);
+        // send: the texture index of the sparkly SCD texture
+        texture_set_stage(stage_mask, tt_texhandle);
+        // send: the texture index of the the gradient used to cycle the colours
+        texture_set_stage(stage_grad, grad_texhandle);
+        
+        shader_set_uniform_f(param_shift, shift); // send the shift amount (for colour cycling) to the shader
+        if (surface_exists(tt_surface)) draw_surface_ext(tt_surface, argument2, argument3, image_xscale, image_yscale, 0, c_white, 1);
+    shader_reset();
+}

--- a/SonicTimeTwisted.gmx/scripts/timetravel_shader_init.gml
+++ b/SonicTimeTwisted.gmx/scripts/timetravel_shader_init.gml
@@ -9,16 +9,35 @@ the white pixels will be replaced with a texture that makes it look like the SCD
 */
 // send some information to the shader; the shader has to be set for this to work
 // (I don't know if this can be screwed up by using other shaders; if so, this info might have to be sent in the draw event...)
-shader_set(TimeTravelShader);
-// send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
-shader_set_uniform_f(shader_get_uniform(TimeTravelShader, "scl"), argument0 / background_get_width(tt_texture), argument1 / background_get_height(tt_texture));
-// send: the texture index of the sparkly SCD texture
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "mask"), background_get_texture(tt_texture));
-// send: the texture index of the the gradient used to cycle the colours
-texture_set_stage(shader_get_sampler_index(TimeTravelShader, "grad"), background_get_texture(tt_gradient));
-shader_reset();
+// fix by nkrapivin: this applies to some platforms other than the PC, like PS4 and Android
+
+tts_ok = shader_is_compiled(TimeTravelShader);
+if (!tts_ok) show_message_async("Could not compile Time Travel Shader!");
+else
+{
+    tt_texhandle = background_get_texture(tt_texture);
+    grad_texhandle = background_get_texture(tt_gradient);
+    tt_width = background_get_width(tt_texture);
+    tt_height = background_get_height(tt_texture);
+    
+    // the parameter handle to be used to send the shift amount to the shader later in the draw event
+    param_shift = shader_get_uniform(TimeTravelShader, "shift");
+    param_scl = shader_get_uniform(TimeTravelShader, "scl");
+    stage_mask = shader_get_sampler_index(TimeTravelShader, "mask");
+    stage_grad = shader_get_sampler_index(TimeTravelShader, "grad");
+    
+    shader_set(TimeTravelShader);
+    // send: the scaling of the sparkly SCD texture so it will repeat enough times to not be stretched
+    shader_set_uniform_f(param_scl, argument0 / tt_width, argument1 / tt_height);
+    // send: the texture index of the sparkly SCD texture
+    texture_set_stage(stage_mask, tt_texhandle);
+    // send: the texture index of the the gradient used to cycle the colours
+    texture_set_stage(stage_grad, grad_texhandle);
+    shader_reset();
+}
+
 // create a surface the size of the screen to draw the effect on
-tt_surface = surface_create(426, 240);
+tt_surface = -1;
 // I've included two types of "zipper animation" - see step event
 type = false;
 // the image index of the animated sprite that will be drawn to the texture
@@ -28,19 +47,3 @@ image_speed = 0;
 // it's also used to slide the texture horizontally to give it some motion, but you could use a 2nd value
 // if the speeds need to be tweaked
 shift = 0;
-// the parameter handle to be used to send the shift amount to the shader later in the draw event
-param_shift = shader_get_uniform(TimeTravelShader, "shift");
-
-
-// fix by nkrapivin: this applies to some platforms other than the PC, like PS4 and Android
-tt_texhandle = background_get_texture(tt_texture);
-grad_texhandle = background_get_texture(tt_gradient);
-tt_width = background_get_width(tt_texture);
-tt_height = background_get_height(tt_texture);
-
-tts_ok = shader_is_compiled(TimeTravelShader);
-if (!tts_ok) show_message_async("Could not compile Time Travel Shader!");
-param_shift = shader_get_uniform(TimeTravelShader, "shift");
-param_scl = shader_get_uniform(TimeTravelShader, "scl");
-stage_mask = shader_get_sampler_index(TimeTravelShader, "mask");
-stage_grad = shader_get_sampler_index(TimeTravelShader, "grad");


### PR DESCRIPTION
What's new:
- set windows exe version to 1.1.0
- added vsync menu option to video settings
- some objects called surface_reset_target while no surface has been set, GMS1 doesn't care, but GMS2 throws an error "Reset target when no target was set", then "UNBALANCED SURFACE STACK", and then it quits.
- also YoYo doesn't recommend creating surfaces in the Create event, rather you should only create a surface right when you need it. (https://docs.yoyogames.com/source/dadiospice/002_reference/surfaces/index.html docs actually say that you should create them in the Draw Event but that's not true)
- enabled "Create textures on Demand" in Windows config because the Windows Runner preloads all texture pages in memory, and draw_texture_flush does nothing (https://docs.yoyogames.com/source/dadiospice/002_reference/drawing/draw_texture_flush.html), but if you tick that checkbox it will only load texture pages when needed like on every other platform. (This is on by default in GMS2 by the way)
- time travel scripts never call shader_set if tts_ok is false, which will prevent the game from crashing.

TL;DR: add vsync to menu, fix errors that happen when importing to GMS2.