### PR TITLE
Give ice shield and earth shield movement options

### DIFF
--- a/SonicTimeTwisted.gmx/scripts/player_is_earth_shielding.gml
+++ b/SonicTimeTwisted.gmx/scripts/player_is_earth_shielding.gml
@@ -63,6 +63,8 @@ if ((left_rock.shot == false && left_rock.broken == false) || (right_rock.shot =
         {
             which_rock.hspeed = (6 * h_firing) + xspeed / 2;
         }
+        xspeed -= which_rock.hspeed;
+        yspeed -= 2;
         which_rock.vspeed = -2;
         which_rock.gravity = 0.21875;
         //which_rock.vspeed = 8 * v_firing;

--- a/SonicTimeTwisted.gmx/scripts/player_is_ice_attacking.gml
+++ b/SonicTimeTwisted.gmx/scripts/player_is_ice_attacking.gml
@@ -10,6 +10,9 @@ jumping = false;
 jump_action = false;
 // timers
 if invulnerable<6 invulnerable = 6;
+// completely stop movement
+xspeed = 0;
+yspeed = 0;
 // ice shards
 for (i=0; i<360; i+=30) with instance_create(x, y, objShieldIceAttack) {image_angle = i; direction = i; speed = 4;}
 // sound


### PR DESCRIPTION
First off: really great job on the game, I'm enjoying it so far. 

However, I was really disappointed with the new additional elemental shields. 2D Sonic games are mostly about platforming and not about combat. The cool thing about the shields is how the open up completely new ways of movement. But having two shields (ice and earth) that have absolutely no impact on the way sonic moves, makes them absolutely uninteresting. (Wind shield on the other hand is too strong in my opinion, but that's not as big an issue.)

Therefore I added ways for both shields to affect movement:
- Ice shield will completely "freeze" the player's speed (just setting x and y speed to 0), which seems thematically appropriate
- Earth shield now has knockback when shooting the rocks. As a nice side effect now you can actually tell when you use them.

Both of those changes open up neat little movement options that you can do with them, which are useful all the time, not only when there are enemies around.

I have no idea if you also take in gameplay changes or if this is mostly for bug fixes, but this is certainly the version I'm going to 100% the game with, as it no longer makes me avoid those two shields because they feel actually impactful now. (I already played most of the game with these changes, didn't notice any bugs. It are very tiny changes anyway.)